### PR TITLE
p11-kit 0.26.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,8 @@
+@echo on
+set BUILD_DIR=build
+
+meson setup %BUILD_DIR% %MESON_ARGS% ^
+    -Dsystemd=disabled
+meson compile -C %BUILD_DIR%
+meson test -C %BUILD_DIR% --print-errorlogs
+meson install -C %BUILD_DIR%

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
-set -x
+set -ex
 
-if [[ $CONDA_BUILD_CROSS_COMPILATION == "1" ]]; then
-    # Get an updated config.sub and config.guess
-    cp $BUILD_PREFIX/share/gnuconfig/config.* .
-    # We need to regenerate the configs for osx-arm64, but we can't use autogen.sh because
-    # 1. it's not included in the release tarball
-    # 2. it's a sh script, which would mess up the shell env upon execution
-    # see https://github.com/p11-glue/p11-kit/blob/7ea59012c2c81473132211e29ea8ebcc1ce31d09/autogen.sh#L19
-    autoreconf --force --install --verbose
-fi
+BUILD_DIR=build
 
-./configure --prefix=$PREFIX \
-            --with-trust-paths=$PREFIX/ssl/cert.pem
-make
-if [[ $CONDA_BUILD_CROSS_COMPILATION != "1" ]]; then
-    make check
-fi
-make install
+MESON_ARGS=(
+    --prefix="${PREFIX}"
+    --libdir=lib
+    -Dsystemd=disabled
+)
+
+meson setup "$BUILD_DIR" "${MESON_ARGS[@]}"
+meson compile -C "$BUILD_DIR"
+
+test_list=$(meson test -C "$BUILD_DIR" --list) 2> /dev/null
+test_list=$(echo $test_list | sed -e "s/^p11-kit:test-transport//" -e "s/p11-kit:test-transport3//")
+
+meson test -C "$BUILD_DIR" $test_list --print-errorlogs
+meson install -C "$BUILD_DIR"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,47 +1,52 @@
-{% set version = "0.25.3" %}
-
+{% set name = "p11-kit" %}
+{% set version = "0.26.1" %}
 
 package:
-  name: p11-kit
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/p11-glue/p11-kit/releases/download/{{ version }}/p11-kit-{{ version }}.tar.xz
-  sha256: d8ddce1bb7e898986f9d250ccae7c09ce14d82f1009046d202a0eb1b428b2adc
+  url: https://github.com/p11-glue/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.xz
+  sha256: 4769f81483a28040cce1dac09a99599f787a8e0dc239a3089d4b0f676b7c4561
 
 build:
   number: 0
-  # Windows: libtasn1 not available
+  # The build is messed up for Windows
+  # Might get back later
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('p11-kit', max_pin='x.x') }}
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
-    - make
-    - pkg-config
-    - gnuconfig  # [unix]
-    - autoconf   # [build_platform != target_platform]
-    - automake   # [build_platform != target_platform]
-    - libtool    # [build_platform != target_platform]
+    - meson
+    - ninja-base
+    - msys2-coreutils  # [win]
   host:
     - libffi
-    - libtasn1
+    - libtasn1         # [unix]
     - ca-certificates
   run:
     - libffi
-    - libtasn1
+    - libtasn1         # [unix]
 
 test:
   commands:
     - p11-kit -h
+    - p11-kit list-modules
+    - p11-kit print-config
 
 about:
   home: https://github.com/p11-glue/p11-kit
   license: MIT
+  license_family: MIT
   license_file: COPYING
   summary: Provides a way to load and enumerate PKCS#11 modules
+  description: Provides a way to load and enumerate PKCS#11 modules
+  doc_url: https://github.com/p11-glue/p11-kit
+  dev_url: https://github.com/p11-glue/p11-kit
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
p11-kit 0.25.3

**Destination channel:** Defaults

### Links

- [PKG-12323]
- dev_url:        https://github.com/p11-glue/p11-kit/tree/0.26.1
- conda_forge:    https://github.com/conda-forge/p11-kit-feedstock

### Explanation of changes:

- new addition to the registry

[PKG-12323]: https://anaconda.atlassian.net/browse/PKG-12323